### PR TITLE
Added cache-loader support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ module.exports = {
 
 -   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**  (optional, default `{}`)
     -   `options.styleLoader` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** style-loader name or path. (optional, default `'style-loader'`)
+    -   `options.cacheLoader` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** cache-loader name or path. (optional, default `'cache-loader'`)
     -   `options.cssLoader` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** css-loader name or path. (optional, default `'css-loader'`)
     -   `options.postcss` **([Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) \| [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean))** Disable or set options for  postcss-loader. (optional, default `undefined`)
     -   `options.sourceMap` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Enable sourcemaps. (optional, default `undefined`)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ module.exports = {
     -   `options.cssLoader` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** css-loader name or path. (optional, default `'css-loader'`)
     -   `options.postcss` **([Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) \| [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean))** Disable or set options for  postcss-loader. (optional, default `undefined`)
     -   `options.sourceMap` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Enable sourcemaps. (optional, default `undefined`)
+    -   `options.cache` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Cache artifacts between builds. (optional, default `true`)
     -   `options.extract` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Enable CSS extraction. (optional, default `undefined`)
     -   `options.minimize` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Enable CSS minimization. (optional, default `undefined`)
     -   `options.cssModules` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Enable CSS modules. (optional, default `undefined`)

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   pre:
     - mkdir ~/.yarn-cache
   node:
-    version: 7
+    version: 8
 
 dependencies:
   pre:

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ export default class HandleCSSLoader {
   constructor({
     styleLoader = 'style-loader',
     cssLoader = 'css-loader',
+    cacheLoader = 'cache-loader',
     postcss,
     sourceMap,
     extract,
@@ -22,6 +23,7 @@ export default class HandleCSSLoader {
   } = {}) {
     this.styleLoader = styleLoader
     this.cssLoader = cssLoader
+    this.cacheLoader = cacheLoader
     this.postcssOptions = postcss
     this.sourceMap = sourceMap
     this.extract = extract
@@ -72,6 +74,17 @@ export default class HandleCSSLoader {
         options: cssLoaderOptions
       }
     ]
+
+    const cacheLoaderOptions = {
+      cacheDirectory: 'node_modules/cache-loader/.cache'
+    }
+
+    if (this.cacheLoader) {
+      use.unshift({
+        loader: this.cacheLoader,
+        options: cacheLoaderOptions
+      })
+    }
 
     if (loader !== 'postcss-loader' && this.postcssOptions !== false) {
       const postcssOptions = {

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ export default class HandleCSSLoader {
     styleLoader = 'style-loader',
     cssLoader = 'css-loader',
     cacheLoader = 'cache-loader',
+    cache = true,
     postcss,
     sourceMap,
     extract,
@@ -24,6 +25,7 @@ export default class HandleCSSLoader {
     this.styleLoader = styleLoader
     this.cssLoader = cssLoader
     this.cacheLoader = cacheLoader
+    this.cache = cache
     this.postcssOptions = postcss
     this.sourceMap = sourceMap
     this.extract = extract
@@ -79,7 +81,7 @@ export default class HandleCSSLoader {
       cacheDirectory: 'node_modules/cache-loader/.cache'
     }
 
-    if (this.cacheLoader) {
+    if (this.cache) {
       use.unshift({
         loader: this.cacheLoader,
         options: cacheLoaderOptions

--- a/test/fixture/empty-options.js
+++ b/test/fixture/empty-options.js
@@ -6,6 +6,11 @@ module.exports = {
       sourceMap: undefined
     }
   }, {
+    loader: 'cache-loader',
+    options: {
+      cacheDirectory: 'node_modules/cache-loader/.cache',
+    }
+  }, {
     loader: 'css-loader',
     options: {
       autoprefixer: false,

--- a/test/fixture/minimize.js
+++ b/test/fixture/minimize.js
@@ -6,6 +6,11 @@ module.exports = {
       sourceMap: undefined
     }
   }, {
+    loader: 'cache-loader',
+    options: {
+      cacheDirectory: 'node_modules/cache-loader/.cache',
+    }
+  }, {
     loader: 'css-loader',
     options: {
       autoprefixer: false,

--- a/test/fixture/sass.js
+++ b/test/fixture/sass.js
@@ -6,6 +6,11 @@ module.exports = {
       sourceMap: undefined
     }
   }, {
+    loader: 'cache-loader',
+    options: {
+      cacheDirectory: 'node_modules/cache-loader/.cache',
+    }
+  }, {
     loader: 'css-loader',
     options: {
       autoprefixer: false,

--- a/test/fixture/sourcemap.js
+++ b/test/fixture/sourcemap.js
@@ -6,6 +6,11 @@ module.exports = {
       sourceMap: true
     }
   }, {
+    loader: 'cache-loader',
+    options: {
+      cacheDirectory: 'node_modules/cache-loader/.cache',
+    }
+  }, {
     loader: 'css-loader',
     options: {
       autoprefixer: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1978,6 +1978,15 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+cache-loader@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/cache-loader/-/cache-loader-1.2.2.tgz#6d5c38ded959a09cc5d58190ab5af6f73bd353f5"
+  dependencies:
+    loader-utils "^1.1.0"
+    mkdirp "^0.5.1"
+    neo-async "^2.5.0"
+    schema-utils "^0.4.2"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"


### PR DESCRIPTION
This makes sass/scss loading much faster by caching the intermediate results.
By default the cache is stored in node_modules so anyone caching the node_modules can benefit between builds.